### PR TITLE
fix: pin GitHub Actions to full SHA (CLOUDEVOPS-4942)

### DIFF
--- a/.github/workflows/sourceguard.yml
+++ b/.github/workflows/sourceguard.yml
@@ -7,7 +7,7 @@ jobs:
       image: sourceguard/sourceguard-cli
     steps:
       - name: Scan
-        uses: CheckPointSW/sourceguard-action@main
+        uses: CheckPointSW/sourceguard-action@ddeadaa391a6defb21ef4228b91956b062c27862 # main
         with:
           SG_CLIENT_ID: ${{ secrets.SG_CLIENT_ID }}
           SG_SECRET_KEY: ${{ secrets.SG_SECRET_KEY }}


### PR DESCRIPTION
## External Actions (pinned to SHA)

**CheckPointSW**

- `CheckPointSW/sourceguard-action@main` → `ddeadaa` · [verify](https://github.com/CheckPointSW/sourceguard-action/commit/ddeadaa391a6defb21ef4228b91956b062c27862)